### PR TITLE
Add initial support for loading assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Assets loading support;
+
 ### Changed
 
 - Change Scene draw API to receive Canvas as an argument;

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 
 <p align="center">
   <a href="#installing">Installing</a> |
+  <a href="#usage">Usage</a> |
   <a href="#basic-example">Basic example</a> |
   <a href="#building">Building</a> |
   <a href="#license">License</a>
@@ -64,6 +65,52 @@ _or_
 
 > For other installation options, or if you want to start developing your own version, check the [building section](#building).
 
+## Usage
+
+<details>
+<summary><b>It loads assets as magic!</b></summary>
+
+For you to use assets in your scene, you just need to define them in this scene constructor. That's it.
+
+```javascript
+class MyScene extends Scene {
+  constructor() {
+    this.myAsset = new MyAssetResource();
+    this.otherAsset = new MyOtherAssetResource();
+  }
+}
+```
+
+The engine is going to handle their loading as magic! When they're ready to use, your scene will be activated.
+
+```javascript
+class MyScene extends Scene {
+  update(elapsedTime) {
+    // assets are guaranteed to be loaded at this moment
+  }
+  
+  draw() {
+    // assets are guaranteed to be loaded at this moment
+  }
+}
+```
+
+During the assets loading, a loading scene will be displayed. There is a default loading scene (a black screen for now), but you can chage for any scene you want:
+
+```javascript
+class MyLoadingScene extends Scene {
+  draw() {
+    // draw a loading message
+  }
+}
+
+const game = new Game(canvas);
+game.loadingScene = new MyLoadingScene();
+game.start();
+```
+
+</details>
+
 ## Basic example
 
 ```js
@@ -73,6 +120,9 @@ import { Game, Scene, rect } from "ace.js";
 class MyGameScene extends Scene {
   constructor() {
     super({ width: 1600, height: 900 });
+    
+    // it loads assets as magic!!
+    this.myAsset = new MyWhateverAsset();
   }
   
   udpate(elapsedTime) {

--- a/examples/loading-assets/index.html
+++ b/examples/loading-assets/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Loading Assets</title>
+</head>
+<body>
+  <canvas id="canvas" width="800" height="600"></canvas>
+  <script src="./index.ts"></script>
+</body>
+</html>

--- a/examples/loading-assets/index.ts
+++ b/examples/loading-assets/index.ts
@@ -15,16 +15,12 @@ class MyGameScene extends Scene {
 
   constructor() {
     super({ width: 1600, height: 900 });
-    this.loadableOne = new MockedLoadable(2000, "error");
-    this.loadableTwo = new MockedLoadable(4000);
+    this.loadableOne = new MockedLoadable(1000, "error");
+    this.loadableTwo = new MockedLoadable(2000);
   }
 
   draw(): void {
-    if (this.isLoadingInitialLoadables) {
-      this.canvas.fillStyle = "red";
-    } else {
-      this.canvas.fillStyle = "green";
-    }
+    this.canvas.fillStyle = "green";
     this.canvas.fill(rect({ x: 0, y: 0, width: 1600, height: 900 }));
   }
 }

--- a/examples/loading-assets/index.ts
+++ b/examples/loading-assets/index.ts
@@ -1,0 +1,34 @@
+import { Game } from "../../src/game";
+import { Scene } from "../../src/scene";
+import { rect } from "../../src/rectangle";
+import { Loadable } from "../../src/loadable";
+import { MockedLoadable } from "../test-utils";
+
+const canvas = document.querySelector("#canvas") as HTMLCanvasElement;
+if (!canvas) {
+  throw new Error("No canvas");
+}
+
+class MyGameScene extends Scene {
+  private loadableOne: Loadable;
+  private loadableTwo: Loadable;
+
+  constructor() {
+    super({ width: 1600, height: 900 });
+    this.loadableOne = new MockedLoadable(2000, "error");
+    this.loadableTwo = new MockedLoadable(4000);
+  }
+
+  draw(): void {
+    if (this.isLoadingInitialLoadables) {
+      this.canvas.fillStyle = "red";
+    } else {
+      this.canvas.fillStyle = "green";
+    }
+    this.canvas.fill(rect({ x: 0, y: 0, width: 1600, height: 900 }));
+  }
+}
+
+const game = new Game(canvas);
+game.currentScene = new MyGameScene();
+game.start();

--- a/examples/test-utils.ts
+++ b/examples/test-utils.ts
@@ -1,18 +1,30 @@
 import { Loadable } from "../src/loadable";
 
 export class MockedLoadable implements Loadable {
+  private _isLoading: boolean = true;
+  private _hasFailedLoading: boolean = false;
+
   constructor(private delay: number, private fail?: string) {
   }
 
-  load(): Promise<MockedLoadable> {
-    return new Promise((resolve: CallableFunction, reject: CallableFunction) => {
-      setTimeout(() => {
-        if (this.fail) {
-          reject(this.fail);
-        } else {
-          resolve(this);
-        }
-      }, this.delay);
-    });
+  load(): void {
+    this._isLoading = true;
+
+    setTimeout(() => {
+      if (this.fail) {
+        this._hasFailedLoading = false;
+      } else {
+        this._hasFailedLoading = true;
+      }
+      this._isLoading = false;
+    }, this.delay);
+  }
+
+  isLoading(): boolean {
+    return this._isLoading;
+  }
+
+  hasFailedLoading(): boolean {
+    return this._hasFailedLoading;
   }
 }

--- a/examples/test-utils.ts
+++ b/examples/test-utils.ts
@@ -1,0 +1,18 @@
+import { Loadable } from "../src/loadable";
+
+export class MockedLoadable implements Loadable {
+  constructor(private delay: number, private fail?: string) {
+  }
+
+  load(): Promise<MockedLoadable> {
+    return new Promise((resolve: CallableFunction, reject: CallableFunction) => {
+      setTimeout(() => {
+        if (this.fail) {
+          reject(this.fail);
+        } else {
+          resolve(this);
+        }
+      }, this.delay);
+    });
+  }
+}

--- a/src/game.ts
+++ b/src/game.ts
@@ -31,6 +31,7 @@ export class Game implements GameLoopProcess {
 
   set currentScene(scene: Scene) {
     this._currentScene = scene;
+    this._currentScene.load();
     this._currentScene.canvas = new Canvas(this._htmlCanvas);
   }
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,15 +1,18 @@
 import { Canvas } from "./canvas";
 import { GameLoopProcess, GameLoop } from "./game-loop";
 import { Scene } from "./scene";
+import { rect } from "./rectangle";
 
 export class Game implements GameLoopProcess {
   private _currentScene: Scene | undefined;
+  private _loadingScene: Scene | undefined;
   private _loop: GameLoop;
 
   constructor(private _htmlCanvas: HTMLCanvasElement) {
     this._loop = new GameLoop(this);
     this._htmlCanvas.tabIndex = 0;
     this._htmlCanvas.focus();
+    this.loadingScene = new DefaultLoadingScene();
   }
 
   start(): void {
@@ -17,9 +20,27 @@ export class Game implements GameLoopProcess {
   }
 
   processLoop(elapsedTime: number): void {
-    this.currentScene.update(elapsedTime);
-    this.currentScene.clearScreen();
-    this.currentScene.performDraw();
+    if (!this._currentScene || this._currentScene.isLoading()) {
+      this.processLoadingLoop(elapsedTime);
+    } else {
+      this.processPlayingLoop(elapsedTime);
+    }
+  }
+
+  private processLoadingLoop(elapsedTime: number): void {
+    if (this._loadingScene) {
+      this.processLoopForScene(this._loadingScene, elapsedTime);
+    }
+  }
+
+  private processPlayingLoop(elapsedTime: number): void {
+    this.processLoopForScene(this.currentScene, elapsedTime);
+  }
+
+  private processLoopForScene(scene: Scene, elapsedTime: number): void {
+    scene.update(elapsedTime);
+    scene.clearScreen();
+    scene.performDraw();
   }
 
   get currentScene(): Scene {
@@ -31,7 +52,27 @@ export class Game implements GameLoopProcess {
 
   set currentScene(scene: Scene) {
     this._currentScene = scene;
-    this._currentScene.load();
-    this._currentScene.canvas = new Canvas(this._htmlCanvas);
+    this.loadScene(this._currentScene);
+  }
+  
+  set loadingScene(scene: Scene) {
+    this._loadingScene = scene;
+    this.loadScene(this._loadingScene);
+  }
+
+  private loadScene(scene: Scene): void {
+    scene.canvas = new Canvas(this._htmlCanvas);
+    scene.load();
+  }
+}
+
+class DefaultLoadingScene extends Scene {
+  constructor() {
+    super({ width: 1600, height: 900 });
+  }
+
+  draw(): void {
+    this.canvas.fillStyle = "black";
+    this.canvas.fill(rect({ x: 0, y: 0, width: this.resolution.width, height: this.resolution.height }));
   }
 }

--- a/src/loadable.ts
+++ b/src/loadable.ts
@@ -1,0 +1,44 @@
+export interface Loadable {
+  load(): Promise<Loadable>;
+}
+
+export function isLoadable(obj: any): obj is Loadable {
+  return "load" in obj && typeof obj.load === "function";
+}
+
+export class LoadablesLoading {
+  private _successfullyLoadedLoadables: Array<Loadable>;
+  private _failedLoadingLoadables: Array<[Loadable, Error]>;
+
+  constructor(private _loadingLoadables: Array<Loadable>) {
+    this._successfullyLoadedLoadables = [];
+    this._failedLoadingLoadables = [];
+
+    this._loadingLoadables.forEach(loadable => {
+      loadable.load()
+        .then(loaded => this.onSuccessfullyLoadedLoadable(loaded))
+        .catch(cause => this.onFailLoadingLoadable(loadable, cause));
+    });
+  }
+
+  private onSuccessfullyLoadedLoadable(loadable: Loadable): void {
+    this._successfullyLoadedLoadables.push(loadable);
+  }
+
+  private onFailLoadingLoadable(loadable: Loadable, cause: Error): void {
+    this._failedLoadingLoadables.push([loadable, cause]);
+  }
+
+  get isLoading(): boolean {
+    const totalLoaded = this._successfullyLoadedLoadables.length + this._failedLoadingLoadables.length;
+    return totalLoaded < this._loadingLoadables.length;
+  }
+
+  get failedLoadingLoadables(): Array<[Loadable, Error]> {
+    return this._failedLoadingLoadables;
+  }
+
+  get successfullyLoadedLoadables(): Array<Loadable> {
+    return this._successfullyLoadedLoadables;
+  }
+}

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -2,10 +2,12 @@ import { Canvas } from "./canvas";
 import { CoordinatesSystem } from "./coordinates-system";
 import { CanvasMouseEvent, CanvasMouseClickListener } from "./mouse";
 import { CanvasKeyboardEvent, CanvasKeydownEventListener } from "./keyboard";
+import { Loadable, LoadablesLoading, isLoadable } from "./loadable";
 import { Resolution } from "./resolution";
 
 export abstract class Scene {
   private _canvas: Canvas | undefined;
+  private _loadingLoadables: LoadablesLoading | undefined;
 
   constructor(private _resolution: Resolution) {
   }
@@ -32,6 +34,30 @@ export abstract class Scene {
 
   onKeydown(event: CanvasKeyboardEvent): void {
     // nothing here
+  }
+
+  load(): void {
+    const propertyDescriptors = Object.getOwnPropertyDescriptors(this);
+    const loadables = Object.values(propertyDescriptors)
+      .map(property => property.value)
+      .filter(isLoadable);
+    this._loadingLoadables = new LoadablesLoading(loadables);
+  }
+
+  get isLoadingInitialLoadables(): boolean {
+    return Boolean(this._loadingLoadables && this._loadingLoadables.isLoading);
+  }
+
+  get failedLoadingLoadables(): Array<[Loadable, Error]> {
+    return this._loadingLoadables
+      ? this._loadingLoadables.failedLoadingLoadables
+      : [];
+  }
+
+  get successfullyLoadedLoadables(): Array<Loadable> {
+    return this._loadingLoadables
+      ? this._loadingLoadables.successfullyLoadedLoadables
+      : [];
   }
 
   set canvas(canvas: Canvas) {

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -5,9 +5,9 @@ import { CanvasKeyboardEvent, CanvasKeydownEventListener } from "./keyboard";
 import { Loadable, LoadablesLoading, isLoadable } from "./loadable";
 import { Resolution } from "./resolution";
 
-export abstract class Scene {
+export abstract class Scene implements Loadable {
   private _canvas: Canvas | undefined;
-  private _loadingLoadables: LoadablesLoading | undefined;
+  private _loadingLoadables: LoadablesLoading = LoadablesLoading.finished();
 
   constructor(private _resolution: Resolution) {
   }
@@ -41,23 +41,21 @@ export abstract class Scene {
     const loadables = Object.values(propertyDescriptors)
       .map(property => property.value)
       .filter(isLoadable);
+
     this._loadingLoadables = new LoadablesLoading(loadables);
+    this._loadingLoadables.load();
   }
 
-  get isLoadingInitialLoadables(): boolean {
-    return Boolean(this._loadingLoadables && this._loadingLoadables.isLoading);
+  isLoading(): boolean {
+    return this._loadingLoadables.isLoading();
   }
 
-  get failedLoadingLoadables(): Array<[Loadable, Error]> {
-    return this._loadingLoadables
-      ? this._loadingLoadables.failedLoadingLoadables
-      : [];
+  hasFailedLoading(): boolean {
+    return this._loadingLoadables.hasFailedLoading();
   }
 
-  get successfullyLoadedLoadables(): Array<Loadable> {
-    return this._loadingLoadables
-      ? this._loadingLoadables.successfullyLoadedLoadables
-      : [];
+  get failedLoadingLoadables(): Array<Loadable> {
+    return this._loadingLoadables.failedLoadingLoadables;
   }
 
   set canvas(canvas: Canvas) {


### PR DESCRIPTION
> **In progress**: I'm going to update the README file to include documentation about how to use assets loading. CHANGELOG also needs to be updated.

---

### What was done?

This pull request introduces a module for loading loadables (assets) that's responsible for managing the loading assets process. Also, the `Scene` and `Game` were updated to use that module API.

_The API for loading an asset is as follows:_

- Declare your assets as properties of your scene, in its constructor, for example:

```javascript
class MyScene extends Scene {
  constructor() {
    this.myAsset1 = new MyLoadableAsset();
    this.myAsset2 = new MyOtherAsset();
  }

  /* update and draw will be called only when all assets are loaded */

  update() {
    // assets are loaded
  }

  draw() {
    // assets are loaded
  }
}
```


- As you can see, the assets loading system will automatically start loading the assets when it's declared in the `Scene` constructor.

- There is also a property accessor for getting the failed loading assets (if some fails): `this.failedLoadingLoadables`.

- The `Game` has a default loading scene that will be displayed when the assets are loading. In the next steps, we're going to implement a way for customizing this loading scene.

---

> For now, there are no implemented assets objects. This pull request is going to able #4 to continue its progress.